### PR TITLE
Advanced search

### DIFF
--- a/bibslurp.el
+++ b/bibslurp.el
@@ -176,10 +176,9 @@ once the search results are returned."
   "Close the bibslurp buffer and restore the previous window
 configuration."
   (interactive)
-  (when (eq major-mode 'bibslurp-mode)
-    (kill-buffer)
-    (when (get-register :bibslurp-window)
-      (jump-to-register :bibslurp-window))))
+  (kill-buffer)
+  (when (get-register :bibslurp-window)
+    (jump-to-register :bibslurp-window)))
 
 (defun bibslurp/build-ads-url (search-string)
   "Helper function which turns a search string (e.g. \"^Quataert
@@ -701,6 +700,7 @@ user for inserting it. "
 
     (set-keymap-parent keymap widget-keymap)
     (define-key keymap "\C-c\C-c" 'bibslurp/advanced-search-send-query)
+    (define-key keymap "q"        'bibslurp-quit)
 
     ;; Databases
     (widget-insert "Databases to query: ")

--- a/bibslurp.el
+++ b/bibslurp.el
@@ -252,7 +252,6 @@ the mode at any time by hitting 'q'."
 	;; Shave off the last newlines
 	(delete-char -4))
       (bibslurp-mode))
-    (window-configuration-to-register :bibslurp-window)
     (switch-to-buffer buf)
     (setq buffer-read-only t)
     (set-buffer-modified-p nil)
@@ -262,6 +261,7 @@ the mode at any time by hitting 'q'."
 (defun bibslurp-query-ads (search-string)
   "Ask for a search string and sends the query to NASA ADS."
   (interactive (list (read-string "Search string: " nil 'bibslurp-query-history)))
+  (window-configuration-to-register :bibslurp-window)
   (bibslurp/search-results (bibslurp/build-ads-url search-string)
 			   search-string))
 
@@ -648,6 +648,7 @@ user for inserting it. "
 (defun bibslurp/advanced-search-widget ()
   "Create the widgets for the ADS advanced search."
   (interactive)
+  (window-configuration-to-register :bibslurp-window)
   (switch-to-buffer "*ADS advanced search*")
   (kill-all-local-variables)
   (let ((inhibit-read-only t))

--- a/bibslurp.el
+++ b/bibslurp.el
@@ -587,6 +587,131 @@ user for inserting it. "
   (interactive)
   (bibslurp/visit-something 'ned number))
 
+;;; Advanced search
+
+(defvar-local bibslurp/advanced-search-authors nil)
+(defvar-local bibslurp/advanced-search-start-mon nil)
+(defvar-local bibslurp/advanced-search-start-year nil)
+(defvar-local bibslurp/advanced-search-end-mon nil)
+(defvar-local bibslurp/advanced-search-end-year nil)
+(defvar-local bibslurp/advanced-search-object nil)
+(defvar-local bibslurp/advanced-search-sim nil)
+(defvar-local bibslurp/advanced-search-ned nil)
+(defvar-local bibslurp/advanced-search-adsobj nil)
+
+(defun bibslurp/advanced-search-build-url
+    (authors start-mon start-year end-mon end-year object sim ned adsobj &rest _ignore)
+  "Return the ADS search url for the advanced search."
+  (let ((base-url "http://adsabs.harvard.edu/cgi-bin/nph-abs_connect?db_key=AST&db_key=PHY&db_key=PRE&qform=AST&arxiv_sel=astro-ph&arxiv_sel=cond-mat&arxiv_sel=cs&arxiv_sel=gr-qc&arxiv_sel=hep-ex&arxiv_sel=hep-lat&arxiv_sel=hep-ph&arxiv_sel=hep-th&arxiv_sel=math&arxiv_sel=math-ph&arxiv_sel=nlin&arxiv_sel=nucl-ex&arxiv_sel=nucl-th&arxiv_sel=physics&arxiv_sel=quant-ph&arxiv_sel=q-bio")
+	(sim-url    (if sim    "&sim_query=YES"    "&sim_query=NO"))
+	(ned-url    (if ned    "&ned_query=YES"    "&ned_query=NO"))
+	(adsobj-url (if adsobj "&adsobj_query=YES" "&adsobj_query=NO"))
+	(intermezzo1 "&aut_logic=OR&obj_logic=OR")
+	(authors-url
+	 (concat "&author=" (replace-regexp-in-string " " "+" authors)))
+	(object-url
+	 (concat "&object=" (replace-regexp-in-string " " "+" object)))
+	(start-mon-url  (concat "&start_mon=" start-mon))
+	(start-year-url (concat "&start_year=" start-year))
+	(end-mon-url  (concat "&end_mon=" end-mon))
+	(end-year-url (concat "&end_year=" end-year))
+	(end-url "&ttl_logic=OR&title=&txt_logic=OR&text=&nr_to_return=200&start_nr=1&jou_pick=ALL&ref_stems=&data_and=ALL&group_and=ALL&start_entry_day=&start_entry_mon=&start_entry_year=&end_entry_day=&end_entry_mon=&end_entry_year=&min_score=&sort=SCORE&data_type=SHORT&aut_syn=YES&ttl_syn=YES&txt_syn=YES&aut_wt=1.0&obj_wt=1.0&ttl_wt=0.3&txt_wt=3.0&aut_wgt=YES&obj_wgt=YES&ttl_wgt=YES&txt_wgt=YES&ttl_sco=YES&txt_sco=YES&version=1"))
+    (concat base-url sim-url ned-url adsobj-url intermezzo1 authors-url
+	    object-url start-mon-url start-year-url end-mon-url end-year-url
+	    end-url)))
+
+(defun bibslurp/advanced-search-send-query ()
+  "Send the query for the advanced search."
+  (interactive)
+  (bibslurp/search-results
+   (bibslurp/advanced-search-build-url
+    (widget-value bibslurp/advanced-search-authors)
+    (widget-value bibslurp/advanced-search-start-mon)
+    (widget-value bibslurp/advanced-search-start-year)
+    (widget-value bibslurp/advanced-search-end-mon)
+    (widget-value bibslurp/advanced-search-end-year)
+    (widget-value bibslurp/advanced-search-object)
+    (widget-value bibslurp/advanced-search-sim)
+    (widget-value bibslurp/advanced-search-ned)
+    (widget-value bibslurp/advanced-search-adsobj)))
+  (kill-buffer "*ADS advanced search*"))
+
+(defun bibslurp/advanced-search-widget ()
+  "Create the widgets for the ADS advanced search."
+  (interactive)
+  (switch-to-buffer "*ADS advanced search*")
+  (kill-all-local-variables)
+  (let ((inhibit-read-only t))
+    (erase-buffer))
+  (remove-overlays)
+
+  ;; Authors
+  (setq bibslurp/advanced-search-authors
+	(widget-create 'editable-field
+		       :size 13
+		       :format
+		       (concat (propertize "Authors"
+					   'font-lock-face '(:weight bold))
+			       ": (Last, First M, one per line) %v")))
+
+  ;; Publication date
+  (widget-insert "\n\n")
+  (widget-insert (propertize "Publication date"
+			     'font-lock-face '(:weight bold)))
+  (widget-insert ":\nbetween ")
+  (setq bibslurp/advanced-search-start-mon
+	(widget-create 'editable-field
+		       :size 13
+		       :format "(MM) %v"))
+  (setq bibslurp/advanced-search-start-year
+	(widget-create 'editable-field
+		       :size 13
+		       :format " (YYYY) %v"))
+  (widget-insert "\n    and ")
+  (setq bibslurp/advanced-search-end-mon
+	(widget-create 'editable-field
+		       :size 13
+		       :format "(MM) %v"))
+  (setq bibslurp/advanced-search-end-year
+	(widget-create 'editable-field
+		       :size 13
+		       :format " (YYYY) %v"))
+
+  ;; Objects
+  (setq bibslurp/advanced-search-object
+	(widget-create 'editable-field
+		       :size 13
+		       :format
+		       (concat "\n\n"
+			       (propertize "Object name/position search"
+					   'font-lock-face '(:weight bold))
+			       ": %v")))
+  (widget-insert "\nSelect data catalogs:\n")
+  (setq bibslurp/advanced-search-sim (widget-create 'checkbox t))
+  (widget-insert " SIMBAD ")
+  (setq bibslurp/advanced-search-ned (widget-create 'checkbox t))
+  (widget-insert " NED ")
+  (setq bibslurp/advanced-search-adsobj (widget-create 'checkbox t))
+  (widget-insert " ADS objects\n\n")
+
+  ;; Buttons
+  (widget-create 'push-button
+		 :notify (lambda (&rest _ignore)
+			   (bibslurp/advanced-search-send-query))
+		 "Send Query")
+  (widget-insert " ")
+  (widget-create 'push-button
+		 :notify (lambda (&rest _ignore)
+			   (bibslurp/advanced-search-widget))
+		 "Clear")
+
+  ;; Setup the widgets
+  (use-local-map widget-keymap)
+  (widget-setup)
+
+  ;; Move to the first widget
+  (widget-forward 1))
+
 (provide 'bibslurp)
 
 ;;; bibslurp.el ends here

--- a/bibslurp.el
+++ b/bibslurp.el
@@ -125,6 +125,9 @@
 ;;; Code:
 (require 's)
 (require 'dash)
+(require 'widget)
+(eval-when-compile
+  (require 'wid-edit))
 
 (defgroup bibslurp nil
   "retrieve BibTeX entries from NASA ADS."
@@ -707,14 +710,14 @@ user for inserting it. "
 	(ttl-logic-url (concat "&ttl_logic=" title-logic))
 	(title-url
 	 (concat "&title=" (replace-regexp-in-string " " "+" title)))
-	(txl-logic-url (concat "&txt_logic=" abstract-logic))
+	(txt-logic-url (concat "&txt_logic=" abstract-logic))
 	(text-url
 	 (concat "&text=" (replace-regexp-in-string " " "+" abstract)))
 	(end-url "&nr_to_return=200&start_nr=1&jou_pick=ALL&ref_stems=&data_and=ALL&group_and=ALL&start_entry_day=&start_entry_mon=&start_entry_year=&end_entry_day=&end_entry_mon=&end_entry_year=&min_score=&sort=SCORE&data_type=SHORT&aut_syn=YES&ttl_syn=YES&txt_syn=YES&aut_wt=1.0&obj_wt=1.0&ttl_wt=0.3&txt_wt=3.0&aut_wgt=YES&obj_wgt=YES&ttl_wgt=YES&txt_wgt=YES&ttl_sco=YES&txt_sco=YES&version=1"))
     (concat base-url ast-url phy-url pre-url sim-url ned-url adsobj-url
 	    aut-logic-url obj-logic-url authors-url object-url start-mon-url
 	    start-year-url end-mon-url end-year-url ttl-logic-url title-url
-	    end-url)))
+	    txt-logic-url text-url end-url)))
 
 (defun bibslurp/advanced-search-send-query (&rest _ignore)
   "Send the query for the advanced search."

--- a/readme.org
+++ b/readme.org
@@ -63,8 +63,19 @@
   #+ATTR_HTML: alt="abstract-view" title="abstract-view" width="602" height="466"
   [[file:images/abstract-view.png]]
 
+** Advanced search
+   You can turn to the ADS advanced search interface, akin to
+   http://adsabs.harvard.edu/abstract_service.html, either by pressing =C-c C-c=
+   after having issued =bibslurp-query-ads=, or directly with =M-x
+   bibslurp-query-ads-advanced-search RET=.  Here you can fill the wanted search
+   fields (authors, publication date, objects, title, abstract) and specify
+   combination logics, and then send the query either with =C-c C-c= or by
+   pressing the button =Send Query=.  Use =TAB= to move through fields, and =q=
+   outside an input field to quit the search interface.
+
 ** Other features
-   You can also visit some useful pages related to each entry:
+   In the ADS search result buffer you can also visit some useful pages related
+   to each entry:
    - on-line data at other data centers, with =d=
    - on-line version of the selected article, with =e=
    - on-line articles in PDF or Postscript, with =f=


### PR DESCRIPTION
I wrote an advanced search interface, similar to http://adsabs.harvard.edu/abstract_service.html (which I actually use a lot), but without any filter or sorting option, etc.  As explained in the README and in commentary to the source file, this interface can be opened with `M-x bibslurp-query-ads-advanced-search RET` or by pressing `C-c C-c` after having issued `M-x bibslurp-query-ads RET`, because maybe someone realizes later that would like to use the advanced interface.

I hope it's good enough :-)
